### PR TITLE
Fix LLVM translation and execution bugs

### DIFF
--- a/libcpu/interface.cpp
+++ b/libcpu/interface.cpp
@@ -320,7 +320,9 @@ cpu_translate_function(cpu_t *cpu)
 
 	LOG("*** Translating...");
 	update_timing(cpu, TIMER_BE, true);
-	cpu->fp[cpu->functions] = cpu->exec_engine->getPointerToFunction(cpu->cur_func);
+	auto func_name = cpu->cur_func->getName();
+	auto fp = reinterpret_cast<void*>(cpu->exec_engine->getFunctionAddress(func_name));
+	cpu->fp[cpu->functions] = fp;
 	assert(cpu->fp[cpu->functions] != NULL);
 	update_timing(cpu, TIMER_BE, false);
 	LOG("done.\n");

--- a/libcpu/interface.cpp
+++ b/libcpu/interface.cpp
@@ -82,6 +82,7 @@ cpu_new(cpu_arch_t arch, uint32_t flags, uint32_t arch_flags)
 	cpu_t *cpu;
 
 	llvm::InitializeNativeTarget();
+	llvm::InitializeNativeTargetAsmPrinter();
 
 	cpu = new cpu_t;
 	assert(cpu != NULL);

--- a/libcpu/interface.cpp
+++ b/libcpu/interface.cpp
@@ -184,9 +184,9 @@ cpu_new(cpu_arch_t arch, uint32_t flags, uint32_t arch_flags)
 	}
 
 	// init LLVM
-	cpu->mod = new Module(cpu->info.name, _CTX());
+	std::unique_ptr<llvm::Module> module_ptr(new Module(cpu->info.name, _CTX()));
+	cpu->mod = module_ptr.get();
 	assert(cpu->mod != NULL);
-	std::unique_ptr<llvm::Module> module_ptr(llvm::CloneModule(*cpu->mod));
 	EngineBuilder builder{std::move(module_ptr)};
 	builder.setEngineKind(EngineKind::Kind::JIT);
 	cpu->exec_engine = builder.create();


### PR DESCRIPTION
The 8086 tests, for example, cause a segmentation fault when run. Fix various issues in LLVM translation and execution steps to make libcpu translated programs run again.