### PR TITLE
libnix: Fix setting/getting termios baud rate on musl

### DIFF
--- a/test/libnix/nix/nix-structs.c
+++ b/test/libnix/nix/nix-structs.c
@@ -871,13 +871,8 @@ termios_to_nix_termios(struct termios const *in,
 	out->c_oflag  = termios_oflag_to_nix_termios_oflag(in->c_oflag);
 	out->c_cflag  = termios_cflag_to_nix_termios_cflag(in->c_cflag);
 	out->c_lflag  = termios_lflag_to_nix_termios_lflag(in->c_lflag);
-#if defined(sun)
 	out->c_ispeed = cfgetispeed(in);
 	out->c_ospeed = cfgetospeed(in);
-#else
-	out->c_ispeed = termios_speed_to_nix_termios_speed(in->c_ispeed);
-	out->c_ospeed = termios_speed_to_nix_termios_speed(in->c_ospeed);
-#endif
 	termios_cc_to_nix_termios_cc(in->c_cc, out->c_cc);
 }
 
@@ -889,12 +884,7 @@ nix_termios_to_termios(struct nix_termios const *in,
 	out->c_oflag  = nix_termios_oflag_to_termios_oflag(in->c_oflag);
 	out->c_cflag  = nix_termios_cflag_to_termios_cflag(in->c_cflag);
 	out->c_lflag  = nix_termios_lflag_to_termios_lflag(in->c_lflag);
-#if defined(sun)
 	cfsetispeed(out, nix_termios_speed_to_termios_speed(in->c_ispeed));
 	cfsetospeed(out, nix_termios_speed_to_termios_speed(in->c_ospeed));
-#else
-	out->c_ispeed = nix_termios_speed_to_termios_speed(in->c_ispeed);
-	out->c_ospeed = nix_termios_speed_to_termios_speed(in->c_ospeed);
-#endif
 	nix_termios_cc_to_termios_cc(in->c_cc, out->c_cc);
 }


### PR DESCRIPTION
Use cfget*/cfset* on all systems, instead of non-standardized c_ispeed
and c_ospeed members of struct termios.

In some implementations these fields are private or don't even exist,
but the functions to get/set them should be available on all systems,
or at least could be easily tested for and conditionally provided when
missing, which is a more robust and portable way to handle it.

Closes: https://github.com/libcpu/libcpu/issues/10